### PR TITLE
Add full docstrings to the 2 API functions

### DIFF
--- a/xlandsat/_composite.py
+++ b/xlandsat/_composite.py
@@ -12,6 +12,42 @@ import xarray as xr
 def composite(scene, bands=("red", "green", "blue"), rescale_to=None):
     """
     Create a composite using the given bands.
+
+    The composite will be an RGBA array if NaNs are present in any band (with
+    transparency of the NaN pixels set to full), or RGB is no NaNs are present.
+    The RGB(A) array is encoded as unsigned 8-bit integers for easier plotting
+    with matplotlib and smaller memory footprint.
+
+    Optionally rescale each band to the given range for improved contrast.
+
+    Parameters
+    ----------
+    scene : :class:`xarray.Dataset`
+        A Landsat scene, as read with :func:`xlandsat.load_scene`.
+    bands : list of str
+        A list of variable names from the scene that will be used as the
+        composite's red, green, and blue channels, respectively.
+    rescale_to : None or list
+        If not None, then should be a list/tuple with the minimum and maximum
+        reflectance ranges to use for rescaling. The same values are used for
+        each band. Bands are rescaled separately. Example: ``rescale_to=[0,
+        0.5]``. Default is None.
+
+    Returns
+    -------
+    composite : :class:`xarray.DataArray`
+        The composite as a 3D ``DataArray`` of type uint8. The first 2
+        dimensions are the same as the scene with the ``"channel"`` added as
+        third dimension. Metadata from the scene is copied to the composite.
+
+    Notes
+    -----
+
+    .. tip::
+
+        Use the :meth:`xarray.DataArray.plot.imshow` method to plot the
+        composite using matplotlib.
+
     """
     nrows, ncols = scene[bands[0]].shape
     if np.any((np.isnan(scene[b]) for b in bands)):


### PR DESCRIPTION
Expand their docstrings to include parameters, returns, and some notes. For the private functions, only a minimal docstring was added.