### PR TITLE
Add codecov configuration file to control reports

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,14 @@
+codecov:
+  notify:
+    require_ci_to_pass: no
+
+coverage:
+  status:
+    patch:
+      default:
+        target: '80'
+        if_no_uploads: error
+        if_not_found: success
+        if_ci_failed: failure
+
+comment: false


### PR DESCRIPTION
Disable the PR comment with the report and set a target coverage for PRs.