### PR TITLE
Use the "all versions" Zenodo DOI in citation

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
 <a href="https://github.com/conda-forge/xlandsat-feedstock"><img src="https://img.shields.io/conda/vn/conda-forge/xlandsat.svg?style=flat-square" alt="Latest version on conda-forge"></a>
 <a href="https://codecov.io/gh/compgeolab/xlandsat"><img src="https://img.shields.io/codecov/c/github/compgeolab/xlandsat/main.svg?style=flat-square" alt="Test coverage status"></a>
 <a href="https://pypi.python.org/pypi/xlandsat"><img src="https://img.shields.io/pypi/pyversions/xlandsat.svg?style=flat-square" alt="Compatible Python versions."></a>
+<a href="https://doi.org/10.5281/zenodo.7395473"><img src="https://img.shields.io/badge/doi-10.5281%2Fzenodo.7395473-blue?style=flat-square" alt="DOI used for citations"></a>
 </p>
 
 ## About

--- a/doc/citing.rst
+++ b/doc/citing.rst
@@ -7,4 +7,4 @@ This is research software **made by scientists**. Citations help us justify the
 effort that goes into building and maintaining this project.
 
 If you used it in your research, please consider citing the latest Zenodo
-archive: https://doi.org/10.5281/zenodo.7395474
+archive: https://doi.org/10.5281/zenodo.7395473


### PR DESCRIPTION
This link doesn't change and resolves to the latest version. So we don't have to update this every release. Add a badge to the README with this DOI.