### PR TITLE
Convert save_scene input to pathlib.Path

### DIFF
--- a/xlandsat/_io.py
+++ b/xlandsat/_io.py
@@ -406,6 +406,7 @@ def save_scene(path, scene):
         metadata read from the MTL file and other CF compliant fields in the
         ``attrs`` attribute.
     """
+    path = pathlib.Path(path)
     mode = "w"
     if len(path.suffixes) > 1:
         mode = f"{mode}:{path.suffixes[-1][1:]}"


### PR DESCRIPTION
Forgot to convert the input path name so that strings could be used as input.