### PR TITLE
Update jupyter-sphinx and add ipykernel

### DIFF
--- a/env/requirements-docs.txt
+++ b/env/requirements-docs.txt
@@ -2,7 +2,8 @@
 sphinx==4.5.*
 sphinx-book-theme==0.3.*
 sphinx-copybutton==0.5.*
-jupyter-sphinx==0.3.*
+jupyter-sphinx==0.4.*
 sphinx-design==0.1.*
 myst-parser==0.15.*
 matplotlib
+ipykernel

--- a/environment.yml
+++ b/environment.yml
@@ -22,10 +22,11 @@ dependencies:
   - sphinx==4.5.*
   - sphinx-book-theme==0.3.*
   - sphinx-copybutton==0.5.*
-  - jupyter-sphinx==0.3.*
+  - jupyter-sphinx==0.4.*
   - sphinx-design==0.1.*
   - myst-parser==0.15.*
   - matplotlib
+  - ipykernel
   # Style
   - black
   - pathspec


### PR DESCRIPTION
Current builds were failing because of the lack of the ipykernel package. Add it as a dependency to fix the documentation build.