### PR TITLE
Use np.abs in pansharpen to avoid sign issues

### DIFF
--- a/xlandsat/_pansharpen.py
+++ b/xlandsat/_pansharpen.py
@@ -4,6 +4,7 @@
 """
 Pansharpening methods.
 """
+import numpy as np
 
 
 def pansharpen(scene, panchromatic, weights=(1, 1, 0.2)):
@@ -39,9 +40,9 @@ def pansharpen(scene, panchromatic, weights=(1, 1, 0.2)):
         panchromatic, method="nearest", kwargs={"fill_value": "extrapolate"}
     )
     band_average = sum(
-        sharp[band] * weight for band, weight in zip(bands, weights)
+        np.abs(sharp[band]) * weight for band, weight in zip(bands, weights)
     ) / sum(weights)
-    sharp *= panchromatic
+    sharp *= np.abs(panchromatic)
     sharp /= band_average
     sharp.attrs = {
         key: value for key, value in scene.attrs.items() if key not in ("mtl_file")


### PR DESCRIPTION
The band average calculation and multiplication with the pan band from the original method assumes we're operating on the DN values, which are all positive. But since we do this on reflectance instead, we need to take absolute values when doing these to avoid issues with signs flipping in the output.