### PR TITLE
Add function to fill missing values by interpolation

### DIFF
--- a/doc/api/index.rst
+++ b/doc/api/index.rst
@@ -25,6 +25,7 @@ Processing
 
     composite
     pansharpen
+    interpolate_missing
 
 Sample datasets
 ---------------

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -152,6 +152,7 @@ Here's a quick example:
     composites.rst
     indices.rst
     pansharpen.rst
+    missing-values.rst
     plot-overlay.rst
 
 .. toctree::

--- a/doc/missing-values.rst
+++ b/doc/missing-values.rst
@@ -1,0 +1,69 @@
+.. _missing-values:
+
+Filling missing values
+======================
+
+Landsat Level 2 data can sometimes contain missing values, particularly around
+bright clouds with dark shadows. These pixels will have a value of
+``numpy.nan`` and can cause problems in other calculations. To fill them, we
+can use the values of neighboring pixels to interpolate the missing values with
+:func:`xlandsat.interpolate_missing`.
+
+Let's use our sample scene of the December 2015 eruption of `Momotombo volcano
+<https://en.wikipedia.org/wiki/Momotombo>`__, Nicaragua, to demonstrate how
+it's done.
+
+First, we'll import the required packages and load the sample scene:
+
+.. jupyter-execute::
+
+    import xlandsat as xls
+    import matplotlib.pyplot as plt
+    import xarray as xr
+    import numpy as np
+
+    path = xls.datasets.fetch_momotombo()
+    scene = xls.load_scene(path)
+
+Now we can plot an RGB composite to show some of the missing values. In order
+to highlight them, we'll color the background of the plot in magenta so that
+the missing values don't simply show up as white:
+
+.. jupyter-execute::
+
+    # Make the composite and add it to the scene
+    rgb = xls.composite(scene, rescale_to=(0.04, 0.17))
+
+    fig, ax = plt.subplots(1, 1, figsize=(10, 6))
+
+    rgb.plot.imshow(ax=ax)
+
+    ax.set_facecolor("magenta")
+    ax.set_aspect("equal")
+
+    plt.show()
+
+We can fill these values with reasonable estimates using interpolation:
+
+.. jupyter-execute::
+
+    scene_filled = xls.interpolate_missing(scene)
+
+    rgb_filled = xls.composite(scene_filled, rescale_to=(0.04, 0.17))
+
+    fig, ax = plt.subplots(1, 1, figsize=(10, 6))
+
+    rgb_filled.plot.imshow(ax=ax)
+
+    ax.set_facecolor("magenta")
+    ax.set_aspect("equal")
+
+    plt.show()
+
+The interpolated scene no longer contains the magenta patches!
+
+.. warning::
+
+   This method works well when the missing data are only a few pixels or small
+   patches. Large portions of the image missing cannot be filled in accurately
+   by interpolation.

--- a/xlandsat/__init__.py
+++ b/xlandsat/__init__.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: MIT
 from . import datasets
 from ._composite import composite
+from ._interpolation import interpolate_missing
 from ._io import load_panchromatic, load_scene, save_scene
 from ._pansharpen import pansharpen
 from ._version import __version__

--- a/xlandsat/_interpolation.py
+++ b/xlandsat/_interpolation.py
@@ -1,0 +1,71 @@
+# Copyright (c) 2022 The xlandsat developers.
+# Distributed under the terms of the MIT License.
+# SPDX-License-Identifier: MIT
+"""
+Interpolation methods for scenes.
+"""
+import numpy as np
+import scipy as sp
+
+
+def interpolate_missing(scene, pixel_radius=20):
+    """
+    Fill missing values (NaNs) in a scene by cubic interpolation
+
+    Each missing value is filled by interpolating the pixels within a
+    neighboring region (controlled by ``pixel_radius``) using a piecewise cubic
+    2D interpolator. Interpolation is done for each band in a scene separately.
+
+    Note that this is mostly good if there are a few missing values, not large
+    regions of the scene.
+
+    Parameters
+    ----------
+    scene : :class:`xarray.Dataset`
+        A Landsat scene, as read with :func:`xlandsat.load_scene`.
+    pixel_radius : int
+        Number of pixels to the east, west, south, and north of a missing value
+        that will be used for interpolation. Smaller values make for faster
+        interpolation but may lead to bad results if many missing values are
+        grouped together.
+
+    Returns
+    -------
+    filled_scene : :class:`xarray.Dataset`
+        The scene with missing values filled in.
+    """
+    filled_scene = scene.copy(deep=True)
+    rows, columns = np.meshgrid(
+        np.arange(scene.northing.size),
+        np.arange(scene.easting.size),
+        indexing="ij",
+    )
+    for band in scene:
+        values = filled_scene[band].values
+        nans = np.isnan(values)
+        for i, j in zip(rows[nans], columns[nans]):
+            imin, imax = _search_range(i, pixel_radius, scene.northing.size)
+            jmin, jmax = _search_range(j, pixel_radius, scene.easting.size)
+            valid = ~np.isnan(values[imin:imax, jmin:jmax])
+            interpolator = sp.interpolate.CloughTocher2DInterpolator(
+                (
+                    rows[imin:imax, jmin:jmax][valid],
+                    columns[imin:imax, jmin:jmax][valid],
+                ),
+                values[imin:imax, jmin:jmax][valid],
+            )
+            values[i, j] = interpolator(i, j)
+    return filled_scene
+
+
+def _search_range(index, pixel_radius, dim_size):
+    """
+    Get a valid range around the index to search for interpolation data.
+    Mostly used to avoid overflowing the image boundaries.
+    """
+    left, right = index - pixel_radius, index + pixel_radius
+    if left < 0:
+        left = 0
+    if right > dim_size:
+        right = dim_size
+    return left, right


### PR DESCRIPTION
The new functions looks at a given region of the scene around a NaN pixel (controlled by a parameter) and uses cubic interpolation to fill the missing value. Decent for smaller patches of NaNs.