### PR TITLE
Remove Dataset assign in indices tutorial

### DIFF
--- a/doc/indices.rst
+++ b/doc/indices.rst
@@ -8,13 +8,10 @@ quantitatively analyze these data.
 They take advantage of different spectral properties of materials to
 differentiate between them.
 Many of these indices can be calculated with simple arithmetic operations.
-So now that our data are in :class:`xarray.Dataset`'s it's fairly easy to
+So now that our data are in :class:`xarray.Dataset`'s, it's fairly easy to
 calculate them.
 
-NDVI
-----
-
-As an example, let's load two example scenes from the
+As an example, let's load two example scenes from before and after the
 `Brumadinho tailings dam disaster <https://en.wikipedia.org/wiki/Brumadinho_dam_disaster>`__:
 
 .. jupyter-execute::
@@ -29,6 +26,9 @@ As an example, let's load two example scenes from the
     after = xls.load_scene(path_after)
 
 
+NDVI
+----
+
 We can calculate the
 `NDVI <https://en.wikipedia.org/wiki/Normalized_difference_vegetation_index>`__
 for these scenes to see if we can isolate the effect of the flood following the
@@ -37,20 +37,16 @@ dam collapse:
 
 .. jupyter-execute::
 
-    before = before.assign(
-        ndvi=(before.nir - before.red) / (before.nir + before.red),
-    )
-    after = after.assign(
-        ndvi=(after.nir - after.red) / (after.nir + after.red),
-    )
+    ndvi_before = (before.nir - before.red) / (before.nir + before.red)
+    ndvi_after = (after.nir - after.red) / (after.nir + after.red)
 
     # Set some metadata for xarray to find
-    before.ndvi.attrs["long_name"] = "normalized difference vegetation index"
-    before.ndvi.attrs["units"] = "dimensionless"
-    after.ndvi.attrs["long_name"] = "normalized difference vegetation index"
-    after.ndvi.attrs["units"] = "dimensionless"
+    ndvi_before.attrs["long_name"] = "normalized difference vegetation index"
+    ndvi_before.attrs["units"] = "dimensionless"
+    ndvi_after.attrs["long_name"] = "normalized difference vegetation index"
+    ndvi_after.attrs["units"] = "dimensionless"
 
-    after
+    ndvi_before
 
 And now we can make pseudo-color plots of the NDVI:
 
@@ -59,8 +55,8 @@ And now we can make pseudo-color plots of the NDVI:
     fig, (ax1, ax2) = plt.subplots(2, 1, figsize=(10, 12))
 
     # Limit the scale to [-1, +1] so the plots are easier to compare
-    before.ndvi.plot(ax=ax1, vmin=-1, vmax=1, cmap="RdBu_r")
-    after.ndvi.plot(ax=ax2, vmin=-1, vmax=1, cmap="RdBu_r")
+    ndvi_before.plot(ax=ax1, vmin=-1, vmax=1, cmap="RdBu_r")
+    ndvi_after.plot(ax=ax2, vmin=-1, vmax=1, cmap="RdBu_r")
 
     ax1.set_title(f"Before: {before.attrs['title']}")
     ax2.set_title(f"After: {after.attrs['title']}")
@@ -75,7 +71,7 @@ taking the difference:
 
 .. jupyter-execute::
 
-    ndvi_change = before.ndvi - after.ndvi
+    ndvi_change = ndvi_before - ndvi_after
     ndvi_change.name = "ndvi_change"
     ndvi_change.attrs["long_name"] = (
         f"NDVI change between {before.attrs['date_acquired']} and "


### PR DESCRIPTION
Avoid assigning the NDVI to the original scene. This is not great practice for later calculations and makes the code more complicated for newcomers.