### PR TITLE
Fix wrong mention of color in indices tutorial

### DIFF
--- a/doc/indices.rst
+++ b/doc/indices.rst
@@ -100,4 +100,4 @@ Now lets plot it:
 
 There's some noise in the cloudy areas of both scenes in the northeast but
 otherwise this plots highlights the area affected by flooding from the dam
-collapse in bright red at the center.
+collapse in purple at the center.


### PR DESCRIPTION
The last part mentioned a "bright red" area which is now purple because of a previous change of colormap.