### PR TITLE
Fix version number for uploading to TestPyPI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [tool.setuptools_scm]
 version_scheme =  "post-release"
+local_scheme =  "node-and-date"
 write_to =  "xlandsat/_version_generated.py"
 
 # Make sure isort and Black are compatible


### PR DESCRIPTION
The `sed` command for replacement wasn't working because the configuration option didn't exist. Add it back so that the push to Test PyPI works.