### PR TITLE
Histogram equalization should use HSV color space

### DIFF
--- a/doc/equalize-histogram.rst
+++ b/doc/equalize-histogram.rst
@@ -64,8 +64,12 @@ in the cloud-free regions:
 
 But, as we mentioned earlier, this means we don't get to see details of the
 clouds anymore. For a more pleasing image, we can use the adaptive histogram
-equalization in :func:`xlandsat.equalize_histogram`. It helps to do a bit of
-contrast stretching first, but to a lesser degree than we did previously.
+equalization in :func:`xlandsat.equalize_histogram`.
+
+.. tip::
+
+    It can be helpful to do a bit of contrast stretching first, but to a lesser
+    degree than we did previously.
 
 .. jupyter-execute::
 


### PR DESCRIPTION
Fix the previous error in histogram equalization, where I did each channel separately. This makes no sense. First convert to HSV and then equalize only the V values. Much better results without that red shift to the results.