### PR TITLE
Add missing Scipy dependency

### DIFF
--- a/doc/install.rst
+++ b/doc/install.rst
@@ -52,6 +52,7 @@ These required dependencies should be installed automatically when you install
 xlandsat with ``pip`` or ``conda``:
 
 * `numpy <http://www.numpy.org/>`__
+* `scipy <https://scipy.org>`__
 * `xarray <https://xarray.dev/>`__
 * `scikit-image <https://scikit-image.org/>`__
 * `pooch <https://www.fatiando.org/pooch/>`__

--- a/environment.yml
+++ b/environment.yml
@@ -8,6 +8,7 @@ dependencies:
   - make
   # Run
   - numpy
+  - scipy
   - xarray
   - scikit-image
   - pooch

--- a/setup.cfg
+++ b/setup.cfg
@@ -37,6 +37,7 @@ packages = find:
 python_requires = >=3.7
 install_requires =
     numpy>=1.19
+    scipy>=1.5
     xarray>=0.16
     scikit-image>=0.18
     pooch>=1.3.0


### PR DESCRIPTION
Was introduced for interpolation but forgot to add it explicitly to the project.