### PR TITLE
Drop support for Python 3.7 and 3.8

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,9 +39,9 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu, macos, windows]
-        python: ["3.7", "3.12"]
+        python: ["3.9", "3.12"]
         include:
-          - python: "3.7"
+          - python: "3.9"
             dependencies: oldest
           - python: "3.12"
             dependencies: latest

--- a/doc/compatibility.rst
+++ b/doc/compatibility.rst
@@ -56,4 +56,6 @@ releases to ensure compatibility:
     * - **Python version**
       - **Last compatible release**
     * - 3.7
-      - Not yet released
+      - v0.5.0
+    * - 3.8
+      - v0.5.0

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -42,7 +42,7 @@ There are different ways to install xlandsat:
 Which Python?
 -------------
 
-You'll need **Python >= 3.7**.
+You'll need **Python >= 3.9**.
 See :ref:`python-versions` if you require support for older versions.
 
 Dependencies

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,19 +19,17 @@ classifiers = [
     "Topic :: Software Development :: Libraries",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.7",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
 ]
-requires-python = ">=3.7"
+requires-python = ">=3.9"
 dependencies = [
-    "numpy>=1.19",
-    "scipy>=1.5",
-    "xarray>=0.16",
-    "scikit-image>=0.18",
+    "numpy>=1.23",
+    "scipy>=1.9",
+    "xarray>=2022.6.0",
+    "scikit-image>=0.19",
     "pooch>=1.3.0",
 ]
 


### PR DESCRIPTION
They are outside of our support range and are causing problems with the GitHub Actions workflows on OSX.